### PR TITLE
prh: Added simple v1 noinversion code

### DIFF
--- a/bigtimer.html
+++ b/bigtimer.html
@@ -824,6 +824,12 @@
 		<span class="bigTimer bigTimerCheck2"><input type="checkbox" class="bigTimer" id="node-input-repeat" placeholder="repeat" > Repeat output</span>
 		<span class="bigTimer bigTimerCheck2"><input type="checkbox" class="bigTimer" id="node-input-atstart" placeholder="atstart" > Output at startup</span>
 		<br/>
+	</div>
+
+	<div>
+		<span class="bigTimer bigTimerCheck2"><input type="checkbox" class="bigTimer" id="node-input-noinversion1" placeholder="repeat" > No inversion timer 1 (&lt;12hr only)</span>
+		<span class="bigTimer bigTimerCheck2"><input type="checkbox" class="bigTimer" id="node-input-noinversion2" placeholder="repeat" > No inversion timer 2 (&lt;12hr only)</span>
+		<br/>
 	</div><br/>
 	
 </div>
@@ -869,6 +875,11 @@
    These include special days (i.e. 25/12) and special weekdays (i.e. first Tuesday of the month) and as of v2.0.0 these can be included or excluded.
    You can if you wish (from v2.3.0 onwards) for example merely turn on BigTimer one day every month of the year by turning off ALL months and using the 12 special days.
    For those occasions where "alternative days" are required there are checkbox options to BAN output on even and/or odd days of the month.
+
+
+  <h3><span style="color:cyan">No Inversions</span></h3>
+  If you use a timer with one fixed time and one dynamic time which varies with the season - you might have a timer that inverts and runs for the better part of the whole day. This option will disable any timer than would run for more than 12 hours.
+  For example a timer set from 7am until sunrise will work over winter, but in the summer when sunrise is before 7am, the timer would normally run from 7am all day and night until sunrise - this is probably not what you want!
 
     <h3><span style="color:cyan">References</span></h3>
 	<p>See the Big Timer doc in the <a target="_blank" href="https://tech.scargill.net/big-timer"> scargill tech blog</a> for more information.</p>
@@ -999,6 +1010,8 @@
      
 			repeat: {value:true, required: false},
 			atstart: {value:true, required: false},
+			noinversion1: {value:false, required: false},
+			noinversion2: {value:false, required: false},
             odd: {value:false, required: false},
             even: {value:false, required: false}
 			},

--- a/bigtimer.js
+++ b/bigtimer.js
@@ -107,6 +107,9 @@ module.exports = function (RED) {
 		node.repeat = n.repeat;
 		node.atStart = n.atstart;
 
+		node.noinversion1 = n.noinversion1;
+		node.noinversion2 = n.noinversion2;
+
 		node.odd = n.odd;
 		node.even = n.even;
 
@@ -579,6 +582,13 @@ module.exports = function (RED) {
 				actualStartTime = (startTime + Number(actualStartOffset)) % 1440;
 				actualEndTime = (endTime + Number(actualEndOffset)) % 1440;
 
+				if ( node.noinversion1 ) { // Zero the timer if inversions are blocked
+					if ( actualEndTime < actualStartTime ) {
+						actualStartTime = 0
+						actualEndTime = 0
+					}
+				}
+
 				if (startTime2 == 5000) startTime2 = dawn;
 				if (startTime2 == 5001) startTime2 = dusk;
 				if (startTime2 == 5002) startTime2 = solarNoon;
@@ -612,6 +622,13 @@ module.exports = function (RED) {
 				actualStartTime2 = (startTime2 + Number(actualStartOffset2)) % 1440;
 				actualEndTime2 = (endTime2 + Number(actualEndOffset2)) % 1440;
 				
+				if ( node.noinversion2 ) { // Zero the timer if inversions are blocked
+					if ( actualEndTime2 < actualStartTime2 ) {
+						actualStartTime2 = 0
+						actualEndTime2 = 0
+					}
+				}
+
 				
 				autoState = 0; goodDay = 0;
 				switch (now.getDay()) {


### PR DESCRIPTION
Since you are collecting code for BigTimer I thought perhaps you'd be interested in a little add-on.

I want  a timer that has one fixed and one dynamic time to not "invert" over seasonal variation (ie a light that should only come on on during dark mornings should not suddenly be on all day and night in the summer!)

Could you review the code I've changed? I'm forwarding it to Peter too.

I really would like to spend a little more time on the inversion. At the moment it is very simple - is the end time going to be earlier than the start time - it wrap through midnight. Ideally it would really check to see if the "on" time will be greater than 12 hours which would allow for timers over midnight still not inverting. 